### PR TITLE
Add SoRAIM 2026 Winter School to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Name | Venue | Date | Deadline :alarm_clock: | Organizers | Fee :euro: | Scholar
 ------|--|---|---|--|-|-| 
 [European Summer School on Artificial Intelligence (ESSAI 2026)](https://essai2026.eu/) | Vienna, Austria | 6 - 10 July 2026 | N/A | TU Wien, WU Wien | N/A | Limited number available
 [1st Internationa School on the Cognitive, Ethical, and Societal Dimensions of AI - AIces](https://aices.irdta.eu/2026/) | Porto, Portugal | 30 Mar - 3 Apr 2026 | 25 November, and onwards| Institute for Research Development, Training and Advice – IRDTA | 340 Euros - 670 Euros | Limited number available
+[Winter School on Social Robotics, Artificial Intelligence and Multimedia (SoRAIM 2026)](https://soraim26.imag.fr/) | Autrans, France | 9 - 13 February 2026 | 09 December 2025 | NAVER LABS Europe | 700 Euros (includes accommodation) | N/A
 [Machine Learning Summer School (MLSS) Melbourne](https://www.mlss-melbourne.com/) | Melbourne, Australia | 2 - 13 February 2026 | 31 August 2025 | Maincode, Australia | 500 AUD | Limited number available
 [IAPR/IEEE Winter School on Biometrics](https://www.comp.hkbu.edu.hk/wsb2026/) | Shenzhen, China | 25 - 29 January 2026 | 29 November 2025 | Hong Kong Baptist University, IAPR, IEEE | 5500 CNY - 7000 CNY | Student grants available
 [Northern Lights Deep Learning Winter School](https://www.nldl.org/home) | Tromsø, Norway,  | 5 - 9 January 2026 | 31 August 2025 | The Arctic University of Norway | 1750 NOK for students, 2500 NOK for academics | Limited number available
@@ -229,4 +230,5 @@ Name | Venue | Date | Deadline :alarm_clock: | Organizers | Fee :euro: | Scholar
 - No. However, some of the enteries in the lists may overlap. The purpose is to share the opportunities with the community and aspiring AI researchers/engineers, data scientists.  
 
 </details>
+
 


### PR DESCRIPTION
This PR adds the **Winter School on Social Robotics, Artificial Intelligence and Multimedia (SoRAIM 2026)** to the 2026 list.